### PR TITLE
fix: FR descriptions defaults were inversed

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -31,8 +31,8 @@ const requiredInfos = [
   { name: 'LINK', message: 'Link to the main page of the vendor' },
   { name: 'SHORT_DESCRIPTION_EN', message: 'A short description in English', default: 'Short description' },
   { name: 'LONG_DESCRIPTION_EN', message: 'A longer description in English', default: 'Long description' },
-  { name: 'SHORT_DESCRIPTION_FR', message: 'A short description in French', default: 'Description longue' },
-  { name: 'LONG_DESCRIPTION_FR', message: 'A longer description in French', default: 'Description courte' },
+  { name: 'SHORT_DESCRIPTION_FR', message: 'A short description in French', default: 'Description courte' },
+  { name: 'LONG_DESCRIPTION_FR', message: 'A longer description in French', default: 'Description longue' },
   { name: 'SOURCE', message: 'Git repository of your connector', default: 'https://github.com/konnectors/my-konnector.git' }
 ]
 


### PR DESCRIPTION
`SHORT_DESCRIPTION_FR` default was `description longue` and `LONG_DESCRIPTION_FR` was `description courte`.