### PR TITLE
doc: add `yo` in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Konnector generator
 This is a Yeoman generator to create Cozy konnectors.
 
 ```
-npm install -g generator-cozy-konnector
+npm install -g yo generator-cozy-konnector
 yo cozy-konnector
 ```
 


### PR DESCRIPTION
Copy/pasting the install command present in the readme results in an error if you don't have `yo` installed. I think we should add it, so everyone can copy/paste the command without getting any error.